### PR TITLE
Fix #7 split tables to separate files for import

### DIFF
--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -83,6 +83,9 @@ class PostgresToRedshift
   def copy_table(table)
     tmpfile = Tempfile.new("psql2rs")
     zip = Zlib::GzipWriter.new(tmpfile)
+    chunksize = 5 * 1024 * 1024 * 1024
+    chunk = 1
+    bucket.objects.with_prefix("export/#{table.target_table_name}.psv.gz").delete_all
     begin
       puts "Downloading #{table}"
       copy_command = "COPY (SELECT #{table.columns_for_copy} FROM #{table.name}) TO STDOUT WITH DELIMITER '|'"
@@ -90,21 +93,31 @@ class PostgresToRedshift
       source_connection.copy_data(copy_command) do
         while row = source_connection.get_copy_data
           zip.write(row)
+          if (zip.pos() > chunksize)
+            zip.finish
+            tmpfile.rewind
+            upload_table(table, tmpfile, chunk)
+            chunk += 1
+            zip.close unless zip.closed?
+            tmpfile.unlink
+            tmpfile = Tempfile.new("psql2rs")
+            zip = Zlib::GzipWriter.new(tmpfile)
+          end
         end
       end
       zip.finish
       tmpfile.rewind
-      upload_table(table, tmpfile)
+      upload_table(table, tmpfile, chunk)
     ensure
       zip.close unless zip.closed?
       tmpfile.unlink
     end
   end
 
-  def upload_table(table, buffer)
-    puts "Uploading #{table.target_table_name}"
-    bucket.objects["export/#{table.target_table_name}.psv.gz"].delete
-    bucket.objects["export/#{table.target_table_name}.psv.gz"].write(buffer, acl: :authenticated_read)
+  def upload_table(table, buffer, chunk)
+    puts "Uploading #{table.target_table_name}.#{chunk}"
+    bucket.objects["export/#{table.target_table_name}.psv.gz.#{chunk}"].delete
+    bucket.objects["export/#{table.target_table_name}.psv.gz.#{chunk}"].write(buffer, acl: :authenticated_read)
   end
 
   def import_table(table)

--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -14,6 +14,10 @@ class PostgresToRedshift
 
   attr_reader :source_connection, :target_connection, :s3
 
+  KILOBYTE = 1024
+  MEGABYTE = KILOBYTE * 1024
+  GIGABYTE = MEGABYTE * 1024
+
   def self.update_tables
     update_tables = PostgresToRedshift.new
 
@@ -83,7 +87,7 @@ class PostgresToRedshift
   def copy_table(table)
     tmpfile = Tempfile.new("psql2rs")
     zip = Zlib::GzipWriter.new(tmpfile)
-    chunksize = 5 * 1024 * 1024 * 1024
+    chunksize = 5 * GIGABYTE # uncompressed
     chunk = 1
     bucket.objects.with_prefix("export/#{table.target_table_name}.psv.gz").delete_all
     begin

--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -97,7 +97,7 @@ class PostgresToRedshift
       source_connection.copy_data(copy_command) do
         while row = source_connection.get_copy_data
           zip.write(row)
-          if (zip.pos() > chunksize)
+          if (zip.pos > chunksize)
             zip.finish
             tmpfile.rewind
             upload_table(table, tmpfile, chunk)

--- a/lib/postgres_to_redshift.rb
+++ b/lib/postgres_to_redshift.rb
@@ -120,7 +120,6 @@ class PostgresToRedshift
 
   def upload_table(table, buffer, chunk)
     puts "Uploading #{table.target_table_name}.#{chunk}"
-    bucket.objects["export/#{table.target_table_name}.psv.gz.#{chunk}"].delete
     bucket.objects["export/#{table.target_table_name}.psv.gz.#{chunk}"].write(buffer, acl: :authenticated_read)
   end
 


### PR DESCRIPTION
The only change to get this working was uploading multiple files to S3 with a number suffix (`.1`, `.2`, ...).  I chose an arbitrary chunk size which produced ~250M files for me.

For now, all the tables are split up in this way, not just the excessively large ones.  The Redshift `COPY` command didn't need to modified to notice the new convention, since Redshift auto-magically loads all files matching a prefix.  And folders for every table are not required as I had pondered in #7.

I preserved the gem's current file naming convention as the prefix for the S3 files -- `export\TABLE.psv.gz`.  Before uploading a table to S3, I delete all the previous uploads with this prefix.  Previously, there was only one file with the name, so only the exact S3 file ("key") would be deleted.  Since the old name matches the prefix, any files of the old sort will be expunged, as well. So this helps with S3 buckets with pre-existing, un-split, un-suffixed files uploaded by this script.  Any and all old-style S3 files will be deleted and be replaced by the new number-suffixed files.  The fear was that an old-style S3 file would stick around and be re-imported to Redshift.  That won't be a problem it seems.

The code I wrote is a bit ugly and could use some re-work, but it shows it can be done.

Unfortunately, it didn't solve my problems with 66GB tables.  I'm getting an `Invalid connection! (PG::Error)` from the source Postgres database (at RDS for me).